### PR TITLE
update quickjs to v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # QuickJS-NG
 
-This is [QuickJS-NG](https://github.com/quickjs-ng/quick-js) packaged for [Zig](https://ziglang.org).
+This is [QuickJS-NG](https://github.com/quickjs-ng/quickjs) packaged for [Zig](https://ziglang.org).

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.7.0",
     .dependencies = .{
         .@"quickjs-ng" = .{
-            .url = "git+https://github.com/quickjs-ng/quickjs/?ref=v0.8.0#482291286b9960c255ff8765d18a618cc87d89a2",
-            .hash = "122031dfbd898963d70cf7d75e645e7baf254a2106209542431e0658439fe879194d",
+            .url = "git+https://github.com/quickjs-ng/quickjs/?ref=v0.9.0#670492dd342dace0bb7bd6fbfbde8f0bc5651224",
+            .hash = "1220604c702c38f0a93b51bec43ae8b427916196daa7fc515e19d3188e5ff1b47327",
         },
     },
     .paths = .{


### PR DESCRIPTION
This updates quickjs to v0.9.0.

Also made a small fix to the quickjs repo url in the readme.